### PR TITLE
don't fail on amdgpu_query_video_caps_info failures

### DIFF
--- a/lib32-mesa-ps4/mesa.patch
+++ b/lib32-mesa-ps4/mesa.patch
@@ -166,3 +166,30 @@ diff -ruN mesa/src/gallium/winsys/radeon/drm/radeon_drm_winsys.c mesa-patched/sr
           ws->info.max_se = 4;
           break;
        }
+diff -ruN mesa/src/amd/common/ac_gpu_info.c mesa-patched/src/amd/common/ac_gpu_info.c 
+--- mesa/src/amd/common/ac_gpu_info.c
++++ mesa-patched/src/amd/common/ac_gpu_info.c
+@@ -534,19 +534,10 @@
+    info->vram_size_kb = DIV_ROUND_UP(info->vram_size, 1024);
+ 
+    if (info->drm_minor >= 41) {
+-      r = amdgpu_query_video_caps_info(dev, AMDGPU_INFO_VIDEO_CAPS_DECODE,
+-            sizeof(info->dec_caps), &(info->dec_caps));
+-      if (r) {
+-         fprintf(stderr, "amdgpu: amdgpu_query_video_caps_info for decode failed.\n");
+-         return r;
+-      }
+-
+-      r = amdgpu_query_video_caps_info(dev, AMDGPU_INFO_VIDEO_CAPS_ENCODE,
+-            sizeof(info->enc_caps), &(info->enc_caps));
+-      if (r) {
+-         fprintf(stderr, "amdgpu: amdgpu_query_video_caps_info for encode failed.\n");
+-         return r;
+-      }
++      amdgpu_query_video_caps_info(dev, AMDGPU_INFO_VIDEO_CAPS_DECODE,
++                                   sizeof(info->dec_caps), &(info->dec_caps));
++      amdgpu_query_video_caps_info(dev, AMDGPU_INFO_VIDEO_CAPS_ENCODE,
++                                   sizeof(info->enc_caps), &(info->enc_caps));
+    }
+ 
+    /* Add some margin of error, though this shouldn't be needed in theory. */

--- a/mesa-ps4/mesa.patch
+++ b/mesa-ps4/mesa.patch
@@ -166,3 +166,30 @@ diff -ruN mesa/src/gallium/winsys/radeon/drm/radeon_drm_winsys.c mesa-patched/sr
           ws->info.max_se = 4;
           break;
        }
+diff -ruN mesa/src/amd/common/ac_gpu_info.c mesa-patched/src/amd/common/ac_gpu_info.c 
+--- mesa/src/amd/common/ac_gpu_info.c
++++ mesa-patched/src/amd/common/ac_gpu_info.c
+@@ -534,19 +534,10 @@
+    info->vram_size_kb = DIV_ROUND_UP(info->vram_size, 1024);
+ 
+    if (info->drm_minor >= 41) {
+-      r = amdgpu_query_video_caps_info(dev, AMDGPU_INFO_VIDEO_CAPS_DECODE,
+-            sizeof(info->dec_caps), &(info->dec_caps));
+-      if (r) {
+-         fprintf(stderr, "amdgpu: amdgpu_query_video_caps_info for decode failed.\n");
+-         return r;
+-      }
+-
+-      r = amdgpu_query_video_caps_info(dev, AMDGPU_INFO_VIDEO_CAPS_ENCODE,
+-            sizeof(info->enc_caps), &(info->enc_caps));
+-      if (r) {
+-         fprintf(stderr, "amdgpu: amdgpu_query_video_caps_info for encode failed.\n");
+-         return r;
+-      }
++      amdgpu_query_video_caps_info(dev, AMDGPU_INFO_VIDEO_CAPS_DECODE,
++                                   sizeof(info->dec_caps), &(info->dec_caps));
++      amdgpu_query_video_caps_info(dev, AMDGPU_INFO_VIDEO_CAPS_ENCODE,
++                                   sizeof(info->enc_caps), &(info->enc_caps));
+    }
+ 
+    /* Add some margin of error, though this shouldn't be needed in theory. */


### PR DESCRIPTION
This pull request adds: https://www.mail-archive.com/mesa-commit@lists.freedesktop.org/msg124515.html to the patchset as I've noticed this fails on my ps4 and causes me to not have any acceleration.

I also added a way for the patches to be automatically applied and fixed the source directory in the PKGBUILD, so now all of it compiles properly without manual interference for applying the patches, I used https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mesa-git as an example.

I put the .patch and pkgbuild fixes in separate commits in case you want only one of these